### PR TITLE
fixed typo

### DIFF
--- a/addons/source-python/plugins/es_emulator/eventscripts/wcs/loaders/racepack_builders/es_racepack_builders.txt
+++ b/addons/source-python/plugins/es_emulator/eventscripts/wcs/loaders/racepack_builders/es_racepack_builders.txt
@@ -9,7 +9,7 @@
 
 block load
 {
-	es_load wcs/tools/manifest/builder_bob_the_builde
+	es_load wcs/tools/manifest/builder_bob_the_builder
 	es_load wcs/tools/manifest/builder_donkey_kong
 	es_load wcs/tools/manifest/builder_lego_man
 	es_load wcs/tools/manifest/builder_madcan
@@ -21,7 +21,7 @@ block load
 
 block unload
 {
-	es_unload wcs/tools/manifest/builder_bob_the_builde
+	es_unload wcs/tools/manifest/builder_bob_the_builder
 	es_unload wcs/tools/manifest/builder_donkey_kong
 	es_unload wcs/tools/manifest/builder_lego_man
 	es_unload wcs/tools/manifest/builder_madcan


### PR DESCRIPTION
Fixed a typo that caused loading issue #1 : `[wcs/loaders/racepack_builders/load 12] es_load: Could not open script for wcs/tools/manifest/builder_bob_the_builde`